### PR TITLE
1.1.0

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [ 14, 16, 18, 19 ]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2022 Yusuke Kawasaki
+Copyright (c) 2022-2023 Yusuke Kawasaki
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ interface Fragment {
 ## EMPTY VALUES
 
 Telesy accepts `string`, `number` values and `Fragment`s within the template literals.
-It outputs empty string `""` when `null`, `undefined` and `false` values given.
-Note that it doesn't accept `true` values, on the other hand.
+It outputs empty string `""` when `null`, `undefined` or `false` value is given.
+Note that it doesn't accept the primitive `true` value, on the other hand.
 Specify strings to output explicitly, instead.
 
 ```js

--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ use the bundled CLI command `mustache2telesy` to migrate from Mustache to Telesy
 
 # give some hints of property types to get more simple code generated
 ./node_modules/.bin/mustache2telesy --trim --guess --array="items,itemList" --bool="isHidden,selected" --func="getText" templates/*.html > templates.ts
+
+# if you need a plain CommonJS file instead of ES Module or TypeScript file
+./node_modules/.bin/mustache2telesy --trim --guess --cjs templates/*.html > templates.js
 ```
 
 The author is a Mustache user for more than 10 years.

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ interface Fragment {
 ## EMPTY VALUES
 
 Telesy accepts `string`, `number` values and `Fragment`s within the template literals.
-It outputs empty string `""` when `null`, `undefined` or `false` value is given.
+It outputs empty string `""` when one of `null`, `undefined` or `false` value is given.
 Note that it doesn't accept the primitive `true` value, on the other hand.
 Specify strings to output explicitly, instead.
 
@@ -190,8 +190,8 @@ use the bundled CLI command `mustache2telesy` to migrate from Mustache to Telesy
 The author is a Mustache user for more than 10 years.
 His Mustache-based project was migrated to Telesy/TypeScript just in minutes.
 
-Most of Mustache's basic features would just get transformed by `mustache2telesy`,
-except for some use cases such as lambda function calls.
+Most of Mustache's basic features would just get transformed by `mustache2telesy` CLI.
+You may need to fix the rest by hand.
 But don't be afraid. TypeScript's type checking would help you to fix them easily, anyway.
 
 ## LINKS

--- a/mustache/mustache2telesy.cli.ts
+++ b/mustache/mustache2telesy.cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import * as fs from "fs";
-import {mustache2telesy} from "./parser";
+import {m2tOptions, mustache2telesy} from "./parser";
 
 CLI(process.stdout);
 
@@ -26,17 +26,13 @@ function CLI(stream: { write(str: string): any }) {
 
     stream.write(`import {$$, $$$} from "telesy";\n\n`);
 
-    const options: { [key: string]: boolean | string } = {};
+    const options: m2tOptions = {};
 
     // parsing option arguments
     for (const arg of args) {
         if (/^--\w/.test(arg)) {
             const eq = arg.slice(2).split("=", 2);
-            if (eq.length === 1) {
-                options[eq[0]] = true;
-            } else {
-                options[eq[0]] = eq[1];
-            }
+            (options as any)[eq[0]] = (eq.length === 1) ? true : eq[1];
         }
     }
 

--- a/mustache/mustache2telesy.cli.ts
+++ b/mustache/mustache2telesy.cli.ts
@@ -7,6 +7,7 @@ CLI(process.stdout);
 
 interface Options extends m2tOptions {
     cjs?: true; // --cjs
+    bool?: string;
 }
 
 function CLI(stream: { write(str: string): any }) {
@@ -37,6 +38,9 @@ function CLI(stream: { write(str: string): any }) {
             (options as any)[eq[0]] = (eq.length === 1) ? true : eq[1];
         }
     }
+
+    // alias
+    options.boolean ||= options.bool;
 
     let count = 0;
 

--- a/mustache/mustache2telesy.cli.ts
+++ b/mustache/mustache2telesy.cli.ts
@@ -5,6 +5,10 @@ import {m2tOptions, mustache2telesy} from "./parser";
 
 CLI(process.stdout);
 
+interface Options extends m2tOptions {
+    cjs?: true; // --cjs
+}
+
 function CLI(stream: { write(str: string): any }) {
     // @see https://tc39.es/ecma262/#sec-keywords-and-reserved-words
     const reservedWords = `await break case catch class const continue debugger default delete do
@@ -24,9 +28,7 @@ function CLI(stream: { write(str: string): any }) {
         return;
     }
 
-    stream.write(`import {$$, $$$} from "telesy";\n\n`);
-
-    const options: m2tOptions = {};
+    const options: Options = {};
 
     // parsing option arguments
     for (const arg of args) {
@@ -35,6 +37,8 @@ function CLI(stream: { write(str: string): any }) {
             (options as any)[eq[0]] = (eq.length === 1) ? true : eq[1];
         }
     }
+
+    let count = 0;
 
     // read each files
     for (const arg of args) {
@@ -55,11 +59,25 @@ function CLI(stream: { write(str: string): any }) {
 
         const code = mustache2telesy(source, options);
 
+        if (!count++) {
+            if (options.cjs) {
+                stream.write(`const {$$, $$$} = require("telesy");\n`);
+            } else {
+                stream.write(`import {$$, $$$} from "telesy";\n`);
+            }
+        }
+
+        stream.write(`\n`);
+
         // @see https://www.jetbrains.com/help/idea/using-language-injections.html#use-language-injection-comments
         if (/\.html$/.test(arg)) {
             stream.write(`// language=HTML\n`);
         }
 
-        stream.write(`export const ${name} = ${code};\n\n`);
+        if (options.cjs) {
+            stream.write(`exports.${name} = ${code};\n`);
+        } else {
+            stream.write(`export const ${name} = ${code};\n`);
+        }
     }
 }

--- a/mustache/parser.ts
+++ b/mustache/parser.ts
@@ -116,6 +116,8 @@ declare namespace M2T {
     }
 }
 
+export type m2tOptions = M2T.Option;
+
 export function mustache2telesy(source: string, option?: M2T.Option): string {
     const TAG_MAP = {
         "&": ampersandTag,

--- a/mustache/parser.ts
+++ b/mustache/parser.ts
@@ -275,7 +275,7 @@ export function mustache2telesy(source: string, option?: M2T.Option): string {
         const safe = vars.name(parent, str, true); // => v.obj.obj.key
         layer = layer.push(str, "`) }", true);
 
-        const child = vars.root.match(str) ? rootVar : layer.key;
+        const child = layer.key;
 
         /**
          * Loop Section

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "files": [
     "LICENSE",
     "README.md",
+    "esm/*.js",
     "mustache/*.js",
     "src/*.js",
     "types/*.d.ts"
@@ -44,13 +45,14 @@
   ],
   "license": "MIT",
   "main": "./src/telesy.js",
+  "module": "./esm/telesy.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kawanet/telesy.git"
   },
   "scripts": {
     "benchmark": "node benchmark/bench.js",
-    "build": "./node_modules/.bin/tsc -p .",
+    "build": "./node_modules/.bin/tsc -p tsconfig.json && ./node_modules/.bin/tsc -p tsconfig-esm.json",
     "fixpack": "fixpack",
     "prepack": "npm run build && npm test",
     "test": "./node_modules/.bin/mocha tests/*.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "telesy",
   "description": "Telesy - Type Safe HTML Templating Library using Template Literals",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "author": "@kawanet",
   "bin": {
     "mustache2telesy": "mustache/mustache2telesy.cli.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "telesy",
   "description": "Telesy - Type Safe HTML Templating Library using Template Literals",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "@kawanet",
   "bin": {
     "mustache2telesy": "mustache/mustache2telesy.cli.js"
@@ -14,7 +14,7 @@
     "@types/common-tags": "1.8.1",
     "@types/hogan.js": "3.0.1",
     "@types/mocha": "10.0.1",
-    "@types/node": "18.11.18",
+    "@types/node": "18.13.0",
     "@types/react": "18.0.27",
     "@types/react-dom": "18.0.10",
     "benchmark": "2.1.4",
@@ -26,8 +26,7 @@
     "mustatte": "0.1.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "terser": "5.16.1",
-    "typescript": "4.9.4"
+    "typescript": "4.9.5"
   },
   "files": [
     "LICENSE",

--- a/package.json
+++ b/package.json
@@ -1,33 +1,33 @@
 {
   "name": "telesy",
   "description": "Telesy - Type Safe HTML Templating Library using Template Literals",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "@kawanet",
   "bin": {
     "mustache2telesy": "mustache/mustache2telesy.cli.js"
   },
   "devDependencies": {
-    "@babel/core": "7.19.6",
+    "@babel/core": "7.20.12",
     "@babel/plugin-transform-template-literals": "7.18.9",
-    "@types/babel__core": "7.1.19",
+    "@types/babel__core": "7.20.0",
     "@types/benchmark": "2.1.2",
     "@types/common-tags": "1.8.1",
     "@types/hogan.js": "3.0.1",
-    "@types/mocha": "10.0.0",
-    "@types/node": "18.11.7",
-    "@types/react": "18.0.24",
-    "@types/react-dom": "18.0.8",
+    "@types/mocha": "10.0.1",
+    "@types/node": "18.11.18",
+    "@types/react": "18.0.27",
+    "@types/react-dom": "18.0.10",
     "benchmark": "2.1.4",
     "common-tags": "1.8.2",
     "handlebars": "4.7.7",
     "hogan.js": "3.0.2",
-    "mocha": "10.1.0",
+    "mocha": "10.2.0",
     "mustache": "4.2.0",
     "mustatte": "0.1.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "terser": "5.15.1",
-    "typescript": "4.8.4"
+    "terser": "5.16.1",
+    "typescript": "4.9.4"
   },
   "files": [
     "LICENSE",

--- a/src/telesy.ts
+++ b/src/telesy.ts
@@ -4,6 +4,8 @@
 
 import type {Telesy} from "../";
 
+type Stringify = (v: V) => string;
+type TemplateArgments = [TemplateStringsArray, ...V[]];
 type EscapeFn = (str: string) => string;
 
 const AMP = {"<": "&lt;", "&": "&amp;", ">": "&gt;", '"': "&quot;", "'": "&apos;"};
@@ -12,26 +14,28 @@ const escapeHTML: EscapeFn = v => v.replace(/([<&>"'])/g, ($1: keyof typeof AMP)
 
 const isTemplateStringsArray = (v: any): v is TemplateStringsArray => (v && v.raw && (v.raw.length > 0));
 
-const isFragment = (v: any): v is Telesy.Fragment => ("string" === typeof (v as Telesy.Fragment).outerHTML);
+const isFragment = (v: any): v is Fragment => ("string" === typeof v.outerHTML);
+
+const toString = function (this: Fragment) {
+    return this.outerHTML;
+};
 
 const makeTelesy = (escapeFn: EscapeFn): Telesy.telesy => {
-
-    type Stringify = (v: Telesy.V) => string;
 
     // stringify function with escaping feature
     const stringify$$: Stringify = v => {
         if ("string" === typeof v) {
             return escapeFn(v);
+        } else if ("number" === typeof v) {
+            return escapeFn(String(v));
         } else if (v == null || v === false) {
             return "";
-        }
-
-        if (isFragment(v)) {
+        } else if (isFragment(v)) {
             return v.outerHTML;
         } else if (Array.isArray(v)) {
             return v.map(stringify$$).join(""); // recursive call
         } else {
-            return escapeFn(String(v));
+            return escapeFn(String(v)); // default behaviour
         }
     };
 
@@ -39,21 +43,21 @@ const makeTelesy = (escapeFn: EscapeFn): Telesy.telesy => {
     const stringify$$$: Stringify = v => {
         if ("string" === typeof v) {
             return v;
+        } else if ("number" === typeof v) {
+            return String(v);
         } else if (v == null || v === false) {
             return "";
-        }
-
-        if (isFragment(v)) {
+        } else if (isFragment(v)) {
             return v.outerHTML;
         } else if (Array.isArray(v)) {
             return v.map(stringify$$$).join(""); // recursive call
         } else {
-            return String(v);
+            return String(v); // default behaviour
         }
     };
 
     // template literals
-    const tag$$ = (t: TemplateStringsArray, args: [any, ...string[]]): string => {
+    const tag$$ = (t: TemplateStringsArray, args: TemplateArgments): string => {
         const size = t.length;
         if (size === 1) {
             return t[0];
@@ -64,40 +68,36 @@ const makeTelesy = (escapeFn: EscapeFn): Telesy.telesy => {
         } else {
             let str = t[0];
             for (let i = 1; i < size; i++) {
-                str += stringify$$(args[i]);
+                str += stringify$$(args[i] as V);
                 str += t[i];
             }
             return str;
         }
     };
 
-    const $$: Telesy.$$ = function (t) {
+    const $$ = function (t: TemplateStringsArray | string) {
         if (isTemplateStringsArray(t)) {
             // Template Literals: $$`<div>${v}</div>`
-            return tag$$(t, arguments as any);
+            return tag$$(t, arguments as any as TemplateArgments);
         } else {
             // Function Call: $$($$$("<li>${v}</li>"))
             return stringify$$(t);
         }
-    };
+    } as Telesy.$$;
 
-    const $$$: Telesy.$$$ = function (t) {
+    const $$$ = function (t: TemplateStringsArray | string) {
         if (isTemplateStringsArray(t)) {
-            // Template Literals: $$`<div>${v}</div>`
-            t = tag$$(t, arguments as any);
+            // Template Literals: $$$`<div>${v}</div>`
+            t = tag$$(t, arguments as any as TemplateArgments);
         } else {
             // Function Call: $$($$$("<li>${v}</li>"))
             t = stringify$$$(t);
         }
 
         return {outerHTML: t, toString};
-    };
+    } as Telesy.$$$;
 
     return {$$, $$$};
-}
-
-function toString(this: Telesy.Fragment) {
-    return this.outerHTML;
 }
 
 export const {$$, $$$} = makeTelesy(escapeHTML);

--- a/src/telesy.ts
+++ b/src/telesy.ts
@@ -4,8 +4,8 @@
 
 import type {Telesy} from "../";
 
-type Stringify = (v: V) => string;
-type TemplateArgments = [TemplateStringsArray, ...V[]];
+type Stringify = (v: Telesy.V) => string;
+type TemplateArgments = [TemplateStringsArray, ...Telesy.V[]];
 type EscapeFn = (str: string) => string;
 
 const AMP = {"<": "&lt;", "&": "&amp;", ">": "&gt;", '"': "&quot;", "'": "&apos;"};
@@ -14,9 +14,9 @@ const escapeHTML: EscapeFn = v => v.replace(/([<&>"'])/g, ($1: keyof typeof AMP)
 
 const isTemplateStringsArray = (v: any): v is TemplateStringsArray => (v && v.raw && (v.raw.length > 0));
 
-const isFragment = (v: any): v is Fragment => ("string" === typeof v.outerHTML);
+const isFragment = (v: any): v is Telesy.Fragment => ("string" === typeof v.outerHTML);
 
-const toString = function (this: Fragment) {
+const toString = function (this: Telesy.Fragment) {
     return this.outerHTML;
 };
 
@@ -68,7 +68,7 @@ const makeTelesy = (escapeFn: EscapeFn): Telesy.telesy => {
         } else {
             let str = t[0];
             for (let i = 1; i < size; i++) {
-                str += stringify$$(args[i] as V);
+                str += stringify$$(args[i] as Telesy.V);
                 str += t[i];
             }
             return str;

--- a/tests/820.m2t-options.ts
+++ b/tests/820.m2t-options.ts
@@ -204,4 +204,18 @@ describe(TITLE, () => {
             assert.equal(optionRender(data), `<span>Foo</span>`);
         }
     });
+
+    it(`{root: "foo", array: "foo"}`, () => {
+        const html = `<span>{{#array}}{{#foo}}{{bar}}{{/foo}}{{/array}}</span>`;
+        const normalRender = compile(mustache2telesy(html, {trim: true, array: "array,foo"}));
+        const optionRender = compile(mustache2telesy(html, {trim: true, array: "array,foo", root: "foo"}));
+        assert.doesNotMatch(String(normalRender), /v\.foo/);
+        assert.match(String(optionRender), /v\.foo/);
+
+        {
+            const data = {array: [{foo: [{bar: "in-array"}]}], foo: [{bar: "on-root"}]};
+            assert.equal(normalRender(data), `<span>in-array</span>`);
+            assert.equal(optionRender(data), `<span>on-root</span>`);
+        }
+    });
 });

--- a/tests/820.m2t-options.ts
+++ b/tests/820.m2t-options.ts
@@ -190,4 +190,18 @@ describe(TITLE, () => {
             assert.equal(optionRender(data), `<span>FOO</span>`);
         }
     });
+
+    it(`{root: "foo"}`, () => {
+        const html = `<span>{{#array}}{{foo}}{{/array}}</span>`;
+        const normalRender = compile(mustache2telesy(html, {trim: true, array: "array"}));
+        const optionRender = compile(mustache2telesy(html, {trim: true, array: "array", root: "foo"}));
+        assert.doesNotMatch(String(normalRender), /v\.foo/);
+        assert.match(String(optionRender), /v\.foo/);
+
+        {
+            const data = {foo: "Foo", array: [{foo: "Bar"}]};
+            assert.equal(normalRender(data), `<span>Bar</span>`);
+            assert.equal(optionRender(data), `<span>Foo</span>`);
+        }
+    });
 });

--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -1,0 +1,19 @@
+{
+  "include": [
+    "./src"
+  ],
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "outDir": "./esm",
+    "removeComments": false,
+    "skipLibCheck": true,
+    "strictNullChecks": true,
+    "target": "ES6"
+  }
+}

--- a/types/telesy.d.ts
+++ b/types/telesy.d.ts
@@ -5,6 +5,10 @@
 declare namespace Telesy {
     type V = string | number | false | undefined | null | Fragment | Fragment[];
 
+    // A hack to deny the specific union type of the pair of (Fragment | number). Thanks to Tobias S!
+    type isNotUnionTypeOfFragmentAndNumber<T> = [T] extends [Exclude<V, number>] ? V : [T] extends [Exclude<V, Fragment>] ? V : never;
+    type RestParamsOfV<T extends V[]> = T & { [K in keyof T]: isNotUnionTypeOfFragmentAndNumber<T[K]> };
+
     interface telesy {
         $$: $$;
         $$$: $$$;
@@ -12,7 +16,8 @@ declare namespace Telesy {
 
     interface $$ {
         // Template Literals: $$`<div>${v}</div>`
-        (t: TemplateStringsArray, ...args: V[]): string;
+        // (t: TemplateStringsArray, ...args: V[]): string;
+        <T extends V[]>(t: TemplateStringsArray, ...args: RestParamsOfV<[...T]>): string;
 
         // Function Call: $$($$$("<li>${v}</li>"))
         (t: V): string;
@@ -20,7 +25,8 @@ declare namespace Telesy {
 
     interface $$$ {
         // Template Literals: $$`<ul>${list.map(v => $$$`<li>${v}</li>`)}</ul>`
-        (t: TemplateStringsArray, ...args: V[]): Fragment;
+        // (t: TemplateStringsArray, ...args: V[]): Fragment;
+        <T extends V[]>(t: TemplateStringsArray, ...args: RestParamsOfV<[...T]>): Fragment;
 
         // Function Call: $$$("<li>${v}</li>")
         (t: V): Fragment;


### PR DESCRIPTION
This version denies the specific pairs in union types of `number` and `Fragment[]` as below:

```
# DON'T
${ list.length && list.map(v=>$$$`fragment`) }

# DO
${ !!list.length && list.map(v=>$$$`fragment`) }
```
